### PR TITLE
Scanner updates

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -18,8 +18,8 @@ COMPONENT_SRCDIRS := src
 UPNP_SCAN_TOOL = $(UPNP_TOOLS)/scan/out/Host/debug/firmware/scan$(TOOL_EXT)
 
 .PHONY: upnp-tools
-upnp-tools: ##Build UPnP tools - append SMING_ARCH as required
-	$(Q) $(MAKE) -C $(UPNP_TOOLS)/scan
+upnp-tools: ##Build UPnP tools
+	$(Q) $(MAKE) -C $(UPNP_TOOLS)/scan SMING_ARCH=Host ENABLE_CUSTOM_LWIP=2
 
 $(UPNP_SCAN_TOOL):
 	$(info )

--- a/tools/scan/app/Fetch.h
+++ b/tools/scan/app/Fetch.h
@@ -22,6 +22,7 @@ struct Fetch {
 	String url;
 	String root;
 	String path;
+	String id;
 	State state{State::none};
 	uint8_t attempts{0};
 

--- a/tools/scan/app/application.cpp
+++ b/tools/scan/app/application.cpp
@@ -276,7 +276,7 @@ void fetchNextDescription()
 
 		if(f.attempts < maxDescriptionFetchAttempts) {
 			++f.attempts;
-			debug_i("Fetching '%s'", f.toString().c_str());
+			debug_i("Fetching '%s', attempt #%u", f.toString().c_str(), f.attempts);
 			fetch = &f;
 			break;
 		}
@@ -311,9 +311,10 @@ void fetchNextDescription()
 
 		auto& f = *fetch;
 
-		if(!connection.getResponse()->isSuccess()) {
+		auto response = connection.getResponse();
+		if(!response->isSuccess()) {
 			// Fetch failed, move to end of queue
-			if(f.attempts >= maxDescriptionFetchAttempts) {
+			if(f.attempts >= maxDescriptionFetchAttempts || response->code == HTTP_STATUS_NOT_FOUND) {
 				debug_e("Giving up on '%s' after %u attempts", f.toString().c_str(), f.attempts);
 				f.state = Fetch::State::failed;
 			} else {


### PR DESCRIPTION
Generate log file during scanning, include serviceId in generated schema
Fix debug output
Use MemoryDataStream(maxCapacity) for responses
- Header is queried to allocate only required memory.
- Hard limit set by parameter in constructor.

Give up immediately on NOT_FOUND response, but retry on other errors
- Sometimes get BAD_REQUEST but not necessarily terminal
