### PR TITLE
Add Base64 support

### DIFF
--- a/src/include/Network/UPnP/Base64.h
+++ b/src/include/Network/UPnP/Base64.h
@@ -1,0 +1,67 @@
+/**
+ * Base64.h
+ *
+ * Copyright 2020 mikee47 <mike@sillyhouse.net>
+ *
+ * This file is part of the Sming UPnP Library
+ *
+ * This library is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, version 3 or later.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this library.
+ * If not, see <https://www.gnu.org/licenses/>.
+ *
+ ****/
+
+#pragma once
+
+#include <Network/WebHelpers/base64.h>
+#include <cstring>
+
+namespace UPnP
+{
+class Base64
+{
+public:
+	Base64()
+	{
+	}
+
+	Base64(const String& data) : data(data)
+	{
+	}
+
+	operator String() const
+	{
+		return data;
+	}
+
+	Base64& operator=(const char* value)
+	{
+		if(value == nullptr) {
+			data = nullptr;
+		} else {
+			data = base64_decode(value, strlen(value));
+		}
+		return *this;
+	}
+
+	explicit operator bool() const
+	{
+		return bool(data);
+	}
+
+	String encode() const
+	{
+		return base64_encode(data);
+	}
+
+private:
+	String data;
+};
+
+} // namespace UPnP

--- a/src/include/Network/UPnP/DeviceControl.h
+++ b/src/include/Network/UPnP/DeviceControl.h
@@ -89,7 +89,7 @@ public:
 
 	template <typename T> DeviceControl* getDevice(const T& deviceType)
 	{
-		return getDevice<DeviceControl>(deviceType);
+		return Device::getDevice<DeviceControl>(deviceType);
 	}
 
 	String getField(Field desc) const override;

--- a/src/include/Network/UPnP/Envelope.h
+++ b/src/include/Network/UPnP/Envelope.h
@@ -22,6 +22,7 @@
 #include <RapidXML.h>
 #include "Error.h"
 #include "ErrorCode.h"
+#include "Base64.h"
 
 namespace UPnP
 {
@@ -250,6 +251,12 @@ public:
 	bool getArg(const String& name, float& value, float defaultValue = 0.0);
 	bool getArg(const String& name, double& value, double defaultValue = 0.0);
 
+	bool getArg(const String& name, Base64& value)
+	{
+		value = getArgValue(name);
+		return bool(value);
+	}
+
 	/** @} */
 
 	/**
@@ -297,6 +304,11 @@ public:
 	bool addArg(const String& name, double value)
 	{
 		return addArg(name, String(value));
+	}
+
+	bool addArg(const String& name, const Base64& value)
+	{
+		return addArg(name, value.encode());
 	}
 
 	/** @} */


### PR DESCRIPTION
Not tested, but used by networking devices and required following UPnP-Schema updates